### PR TITLE
Sort map iterations so code generation is stable.

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -33,7 +33,8 @@ var (
 	profile_name := spec.Profile
 
 	result += GenerateProfileCode(profile_name, profile)
-	for struct_name, struct_def := range profile {
+	for _, struct_name := range SortedKeys(profile) {
+		struct_def := profile[struct_name]
 		struct_name := NormalizeName(struct_name)
 		result += GenerateStructCode(struct_name, profile_name, struct_def)
 		if spec.GenerateDebugString {

--- a/enum.go
+++ b/enum.go
@@ -43,7 +43,8 @@ func (self *%[1]s) %[2]s() *Enumeration {
    switch value {
 `, struct_name, field_name, parser_func)
 
-	for k, v := range self.Choices {
+	for _, k := range SortedIntKeys(self.Choices) {
+		v := self.Choices[k]
 		result += fmt.Sprintf(`
       case %d:
          name = "%s"

--- a/profile.go
+++ b/profile.go
@@ -39,9 +39,12 @@ func GenerateProfileCode(
 	result := fmt.Sprintf("type %s struct {\n", profile_name)
 	init := []string{}
 	factories := ""
-	for struct_name, struct_def := range profile {
+	for _, struct_name := range SortedKeys(profile) {
+		struct_def := profile[struct_name]
 		struct_name = NormalizeName(struct_name)
-		for field_name, field_def := range struct_def.Fields {
+		for _, field_name := range SortedKeys(struct_def.Fields) {
+			field_def := struct_def.Fields[field_name]
+
 			result += fmt.Sprintf("    Off_%s_%s int64\n",
 				struct_name, field_name)
 			init = append(init, fmt.Sprintf("%d", field_def.Offset))

--- a/struct.go
+++ b/struct.go
@@ -7,8 +7,8 @@ import (
 
 func GeneratePrototypes() string {
 	result := ""
-	for _, v := range prototypes {
-		result += v
+	for _, k := range SortedKeys(prototypes) {
+		result += prototypes[k]
 	}
 
 	return result
@@ -36,7 +36,8 @@ func (self *%s) Size() int {
 		name,
 		name, definition.Size)
 
-	for field_name, field_def := range definition.Fields {
+	for _, field_name := range SortedKeys(definition.Fields) {
+		field_def := definition.Fields[field_name]
 		result += field_def.GetParser().Compile(name, field_name)
 	}
 
@@ -47,7 +48,8 @@ func GenerateDebugString(name string, profile_name string, definition *StructDef
 	result := fmt.Sprintf(
 		"func (self *%s) DebugString() string {\n    result := fmt.Sprintf("+
 			"\"struct %s @ %%#x:\\n\", self.Offset)\n", name, name)
-	for field_name, field_def := range definition.Fields {
+	for _, field_name := range SortedKeys(definition.Fields) {
+		field_def := definition.Fields[field_name]
 		if field_def.StringParser != nil ||
 			field_def.UTF16StringParser != nil {
 			result += fmt.Sprintf(

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,10 @@
 package binparsergen
 
+import (
+	"reflect"
+	"sort"
+)
+
 func InString(hay []string, needle string) bool {
 	for _, x := range hay {
 		if x == needle {
@@ -8,4 +13,34 @@ func InString(hay []string, needle string) bool {
 	}
 
 	return false
+}
+
+func SortedKeys(any interface{}) []string {
+	if reflect.TypeOf(any).Kind() != reflect.Map {
+		return nil
+	}
+
+	result := []string{}
+	for _, k := range reflect.ValueOf(any).MapKeys() {
+		result = append(result, k.Interface().(string))
+	}
+
+	sort.Strings(result)
+
+	return result
+}
+
+func SortedIntKeys(any interface{}) []int {
+	if reflect.TypeOf(any).Kind() != reflect.Map {
+		return nil
+	}
+
+	result := []int{}
+	for _, k := range reflect.ValueOf(any).MapKeys() {
+		result = append(result, k.Interface().(int))
+	}
+
+	sort.Ints(result)
+
+	return result
 }

--- a/vtypes.go
+++ b/vtypes.go
@@ -28,7 +28,8 @@ func ConvertSpec(spec *ConversionSpec) (map[string]*StructDefinition, error) {
 
 	profile := make(map[string]*StructDefinition)
 
-	for type_name, definition_list := range types {
+	for _, type_name := range SortedKeys(types) {
+		definition_list := types[type_name]
 		if !InString(spec.Structs, type_name) {
 			continue
 		}
@@ -47,7 +48,8 @@ func ConvertSpec(spec *ConversionSpec) (map[string]*StructDefinition, error) {
 			return nil, err
 		}
 
-		for field_name, field_def := range fields {
+		for _, field_name := range SortedKeys(fields) {
+			field_def := fields[field_name]
 			if InString(spec.FieldBlackList[type_name], field_name) {
 				continue
 			}


### PR DESCRIPTION
Without this code generation creates a lot of VCS churn.